### PR TITLE
fix: fix uid and username order in AuthService

### DIFF
--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/AuthService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/AuthService.java
@@ -23,8 +23,8 @@ public class AuthService {
     public User getCurrentUser() {
         FirebaseUser firebaseUser = mAuth.getCurrentUser();
         return new User(
-                username,
                 firebaseUser.getUid(),
+                username,
                 firebaseUser.getDisplayName(),
                 firebaseUser.getEmail(),
                 firebaseUser.getPhoneNumber()


### PR DESCRIPTION
A small bug here that AuthService was creating a User class using `username` as first parameter and `uid` as second parameter, but the User class constructor have the reversed order

so before if I call authService.getInstance().getCurrentUser().getUsername() it will return me the `uid` instead