### PR TITLE
chore: add test to cover user profile search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:1.10.19'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+
+    testImplementation 'android.arch.core:core-testing:1.1.1'
+
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"
 

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/exceptions/UserNotExistException.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/exceptions/UserNotExistException.java
@@ -1,0 +1,7 @@
+package com.cmput301f20t21.bookfriends.exceptions;
+
+public class UserNotExistException extends Exception{
+    public UserNotExistException() {
+        super();
+    }
+}

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
@@ -8,9 +8,12 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.Query;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class UserRepository implements IUserRepository {
     private CollectionReference userCollection;
@@ -55,19 +58,30 @@ public class UserRepository implements IUserRepository {
         return userCollection.document(uid).get();
     }
 
-    public Task<QuerySnapshot> getByUsernameStartWith(String username) {
+    public Task<List<User>> getByUsernameStartWith(String username) {
+        final Query userQuery;
         if (username.length() == 0) {
-            // because username is alphanumeric, according to ascii table, @ is less than 'a' and 0
-            return userCollection.whereEqualTo("username", "@").get();
+            userQuery = userCollection.whereEqualTo("username", "@");
+        } else {
+            userQuery = userCollection
+                    .whereGreaterThanOrEqualTo("username", username)
+                    .whereLessThan("username", username.concat("~")) // ascii ~ is way larger than 'z'
+                    .limit(10);
         }
-        // return a list if 
-        return userCollection
-                .whereGreaterThanOrEqualTo("username", username)
-                .whereLessThan("username", username.concat("~")) // ascii ~ is way larger than 'z'
-                .limit(10).get();
+        return userQuery
+                .get()
+                .continueWith(task -> {
+                    if (!task.getResult().isEmpty()) {
+                        return (ArrayList<User>) task.getResult().getDocuments()
+                                .stream()
+                                .map(doc -> doc.toObject(User.class))
+                                .collect(Collectors.toList());
+                    }
+                    return new ArrayList<>();
+                });
     }
 
-    public Task<Void> updateUserEmail(String email){
+    public Task<Void> updateUserEmail(String email) {
         User firebaseUser = AuthRepository.getInstance().getCurrentUser();
         if (firebaseUser != null) {
             String userId = firebaseUser.getUid();

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
@@ -54,8 +54,15 @@ public class UserRepository implements IUserRepository {
         });
     }
 
-    public Task<DocumentSnapshot> getByUid(String uid) {
-        return userCollection.document(uid).get();
+    public Task<User> getByUid(String uid) {
+        return userCollection.document(uid)
+                .get()
+                .continueWith(task -> {
+                    if (task.getResult() != null) {
+                        return task.getResult().toObject(User.class);
+                    }
+                    return null;
+                });
     }
 
     public Task<List<User>> getByUsernameStartWith(String username) {

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
@@ -69,6 +69,7 @@ public class UserRepository implements IUserRepository {
     public Task<List<User>> getByUsernameStartWith(String username) {
         final Query userQuery;
         if (username.length() == 0) {
+            // because username is alphanumeric, according to ascii table, @ is less than 'a' and 0
             userQuery = userCollection.whereEqualTo("username", "@");
         } else {
             userQuery = userCollection

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/UserRepository.java
@@ -2,6 +2,7 @@ package com.cmput301f20t21.bookfriends.repositories;
 
 import com.cmput301f20t21.bookfriends.entities.User;
 import com.cmput301f20t21.bookfriends.exceptions.UnexpectedException;
+import com.cmput301f20t21.bookfriends.exceptions.UserNotExistException;
 import com.cmput301f20t21.bookfriends.exceptions.UsernameNotExistException;
 import com.cmput301f20t21.bookfriends.repositories.api.IUserRepository;
 import com.google.android.gms.tasks.Task;
@@ -61,7 +62,7 @@ public class UserRepository implements IUserRepository {
                     if (task.getResult() != null) {
                         return task.getResult().toObject(User.class);
                     }
-                    return null;
+                    throw new UserNotExistException();
                 });
     }
 

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/IUserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/IUserRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface IUserRepository {
     Task<Void> add(String uid, String username, String email);
     Task<User> getByUsername(String username);
-    Task<DocumentSnapshot> getByUid(String uid);
+    Task<User> getByUid(String uid);
     Task<List<User>> getByUsernameStartWith(String username);
     Task<Void> updateUserEmail(String email);
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/IUserRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/IUserRepository.java
@@ -5,10 +5,12 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
+import java.util.List;
+
 public interface IUserRepository {
     Task<Void> add(String uid, String username, String email);
     Task<User> getByUsername(String username);
     Task<DocumentSnapshot> getByUid(String uid);
-    Task<QuerySnapshot> getByUsernameStartWith(String username);
+    Task<List<User>> getByUsernameStartWith(String username);
     Task<Void> updateUserEmail(String email);
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
@@ -47,13 +47,8 @@ public class ProfileViewModel extends ViewModel {
 
     public void getUserByUid(String uid, OnSuccessCallbackWithMessage<User> onSuccess, OnFailCallback onFail) {
         userRepository.getByUid(uid)
-                .addOnSuccessListener(user -> {
-                    if (user != null) {
-                        onSuccess.run(user);
-                    } else {
-                        onFail.run();
-                    }
-                });
+                .addOnSuccessListener(onSuccess::run)
+                .addOnFailureListener(e -> onFail.run());
     }
 
     public void updateCurrentUserEmail(String inputEmail, String TAG){

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
@@ -46,23 +46,14 @@ public class ProfileViewModel extends ViewModel {
     }
 
     public void getUserByUid(String uid, OnSuccessCallbackWithMessage<User> onSuccess, OnFailCallback onFail) {
-        userRepository.getByUid(uid).addOnCompleteListener(task -> {
-            if (!task.isSuccessful()) {
-                onFail.run();
-                return;
-            }
-            DocumentSnapshot document = task.getResult();
-            if (document == null) {
-                onFail.run();
-                return;
-            }
-            User u = new User(
-                    document.getId(),
-                    document.get("username").toString(),
-                    document.get("email").toString()
-            );
-            onSuccess.run(u);
-        });
+        userRepository.getByUid(uid)
+                .addOnSuccessListener(user -> {
+                    if (user != null) {
+                        onSuccess.run(user);
+                    } else {
+                        onFail.run();
+                    }
+                });
     }
 
     public void updateCurrentUserEmail(String inputEmail, String TAG){

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/profile/ProfileViewModel.java
@@ -25,7 +25,11 @@ public class ProfileViewModel extends ViewModel {
     private final MutableLiveData<ArrayList<User>> searchedUsers = new MutableLiveData<>(new ArrayList<>());
 
     public ProfileViewModel() {
-        userRepository = UserRepository.getInstance();
+        this(UserRepository.getInstance());
+    }
+
+    public ProfileViewModel(IUserRepository userRepository) {
+        this.userRepository = userRepository;
     }
 
     // the data stream output for searched list views
@@ -36,26 +40,8 @@ public class ProfileViewModel extends ViewModel {
     // the update api for views
     public void updateSearchQuery(String query) {
         // start a search routine, update results
-        userRepository.getByUsernameStartWith(query).addOnCompleteListener(usernameTask -> {
-            if (usernameTask.isSuccessful()) {
-                if (!usernameTask.getResult().isEmpty()) {
-                    ArrayList<User> users = new ArrayList<>();
-                    for (QueryDocumentSnapshot document: usernameTask.getResult()) {
-                        users.add(new User(
-                                document.getId(),
-                                document.get("username").toString(),
-                                document.get("email").toString()
-                        ));
-                    }
-                    searchedUsers.setValue(users);
-                } else {
-                    // empty email, should never happen
-                    searchedUsers.setValue(new ArrayList<>());
-                }
-            } else {
-                // fail to get username
-                searchedUsers.setValue(new ArrayList<>());
-            }
+        userRepository.getByUsernameStartWith(query).addOnSuccessListener(users -> {
+            searchedUsers.setValue((ArrayList<User>) users);
         });
     }
 

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/callbacks/FakeFailCallback.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/callbacks/FakeFailCallback.java
@@ -1,0 +1,10 @@
+package com.cmput301f20t21.bookfriends.fakes.callbacks;
+
+import com.cmput301f20t21.bookfriends.callbacks.OnFailCallback;
+
+public class FakeFailCallback implements OnFailCallback {
+    @Override
+    public void run() {
+
+    }
+}

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/callbacks/FakeSuccessCallbackWithMessage.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/callbacks/FakeSuccessCallbackWithMessage.java
@@ -1,0 +1,9 @@
+package com.cmput301f20t21.bookfriends.fakes.callbacks;
+
+import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallbackWithMessage;
+
+public class FakeSuccessCallbackWithMessage<T> implements OnSuccessCallbackWithMessage<T> {
+    @Override
+    public void run(T msg) {
+    }
+}

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeUserRepository.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeUserRepository.java
@@ -20,7 +20,7 @@ public class FakeUserRepository implements IUserRepository {
     }
 
     @Override
-    public Task<DocumentSnapshot> getByUid(String uid) {
+    public Task<User> getByUid(String uid) {
         return null;
     }
 

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeUserRepository.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeUserRepository.java
@@ -6,6 +6,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
+import java.util.List;
+
 public class FakeUserRepository implements IUserRepository {
     @Override
     public Task<Void> add(String uid, String username, String email) {
@@ -23,7 +25,7 @@ public class FakeUserRepository implements IUserRepository {
     }
 
     @Override
-    public Task<QuerySnapshot> getByUsernameStartWith(String username) {
+    public Task<List<User>> getByUsernameStartWith(String username) {
         return null;
     }
 

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
@@ -1,0 +1,99 @@
+package com.cmput301f20t21.bookfriends.viewmodels;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.Observer;
+
+import com.cmput301f20t21.bookfriends.entities.User;
+import com.cmput301f20t21.bookfriends.fakes.repositories.FakeUserRepository;
+import com.cmput301f20t21.bookfriends.fakes.tasks.FakeSuccessTask;
+import com.cmput301f20t21.bookfriends.ui.profile.ProfileViewModel;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProfileViewModelUnitTest {
+    @Rule
+    public TestRule rule = new InstantTaskExecutorRule();
+    @Mock
+    FakeUserRepository mockUserRepository;
+    // mock the observer. we want it to receive changes and we want to know what change it got
+    @Mock
+    Observer<ArrayList<User>> usersObserver;
+    // the captor is used specifically for the observer, to catch what the observer received, used to get value and assert
+    @Captor
+    ArgumentCaptor<ArrayList<User>> usersResultArgument;
+
+    @Test
+    public void searchSuccess_noResultsOnEmptyInput() {
+        ProfileViewModel vm = new ProfileViewModel(mockUserRepository);
+
+        // start the mock observer
+        vm.getSearchedUsers().observeForever(usersObserver);
+
+        // setup fake parameter to vm
+        String usernameQuery = "";
+        // setup fake response to vm
+        FakeSuccessTask<List<User>> usersTask = new FakeSuccessTask<>(new ArrayList<>());
+        when(mockUserRepository.getByUsernameStartWith(usernameQuery)).thenReturn(usersTask);
+
+        vm.updateSearchQuery(usernameQuery);
+
+        // the first observe call is an empty array
+        verify(usersObserver, times(2)).onChanged(usersResultArgument.capture());
+        verify(mockUserRepository).getByUsernameStartWith(usernameQuery);
+        // assert that the results given from vm and repo are the same
+        ArrayList<User> usersResult = usersResultArgument.getValue(); // getting the latest result
+        assertEquals(usersResult, new ArrayList<User>());
+    }
+
+    @Test
+    public void searchSuccess_noMultipleResults() {
+        ProfileViewModel vm = new ProfileViewModel(mockUserRepository);
+
+        // start the mock observer
+        vm.getSearchedUsers().observeForever(usersObserver);
+
+        String usernameQuery = "test";
+        ArrayList<User> usersResultReal = new ArrayList<>();
+        usersResultReal.add(new User("uid1", "test1", "no1@no.no"));
+        usersResultReal.add(new User("uid2", "test2", "no2@no.no"));
+        usersResultReal.add(new User("uid3", "test3", "no3@no.no"));
+        FakeSuccessTask<List<User>> usersTask = new FakeSuccessTask<>(usersResultReal);
+
+        when(mockUserRepository.getByUsernameStartWith(usernameQuery)).thenReturn(usersTask);
+
+        vm.updateSearchQuery(usernameQuery);
+
+        // the first observe call is an empty array
+        verify(usersObserver, times(2)).onChanged(usersResultArgument.capture());
+        verify(mockUserRepository).getByUsernameStartWith(usernameQuery);
+        // assert that the results given from vm and repo are the same
+        ArrayList<User> usersResult = usersResultArgument.getValue();
+        assertEquals(usersResult, usersResultReal);
+    }
+
+    @Test
+    public void getUserByUidSuccess() {
+
+    }
+
+    @Test
+    public void getUserByUidFailure() {
+
+    }
+}

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
@@ -4,6 +4,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.Observer;
 
 import com.cmput301f20t21.bookfriends.entities.User;
+import com.cmput301f20t21.bookfriends.fakes.callbacks.FakeSuccessCallback;
+import com.cmput301f20t21.bookfriends.fakes.callbacks.FakeSuccessCallbackWithMessage;
 import com.cmput301f20t21.bookfriends.fakes.repositories.FakeUserRepository;
 import com.cmput301f20t21.bookfriends.fakes.tasks.FakeSuccessTask;
 import com.cmput301f20t21.bookfriends.ui.profile.ProfileViewModel;
@@ -27,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProfileViewModelUnitTest {
+    // https://medium.com/pxhouse/unit-testing-with-mutablelivedata-22b3283a7819
     @Rule
     public TestRule rule = new InstantTaskExecutorRule();
     @Mock
@@ -89,11 +92,11 @@ public class ProfileViewModelUnitTest {
 
     @Test
     public void getUserByUidSuccess() {
-
+        // TODO
     }
 
     @Test
     public void getUserByUidFailure() {
-
+        // TODO
     }
 }

--- a/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
+++ b/app/src/test/java/com/cmput301f20t21/bookfriends/viewmodels/ProfileViewModelUnitTest.java
@@ -4,9 +4,11 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.Observer;
 
 import com.cmput301f20t21.bookfriends.entities.User;
-import com.cmput301f20t21.bookfriends.fakes.callbacks.FakeSuccessCallback;
+import com.cmput301f20t21.bookfriends.exceptions.UserNotExistException;
+import com.cmput301f20t21.bookfriends.fakes.callbacks.FakeFailCallback;
 import com.cmput301f20t21.bookfriends.fakes.callbacks.FakeSuccessCallbackWithMessage;
 import com.cmput301f20t21.bookfriends.fakes.repositories.FakeUserRepository;
+import com.cmput301f20t21.bookfriends.fakes.tasks.FakeFailTask;
 import com.cmput301f20t21.bookfriends.fakes.tasks.FakeSuccessTask;
 import com.cmput301f20t21.bookfriends.ui.profile.ProfileViewModel;
 
@@ -40,6 +42,11 @@ public class ProfileViewModelUnitTest {
     // the captor is used specifically for the observer, to catch what the observer received, used to get value and assert
     @Captor
     ArgumentCaptor<ArrayList<User>> usersResultArgument;
+
+    @Mock
+    FakeFailCallback fakeFailUserCallback;
+    @Mock
+    FakeSuccessCallbackWithMessage<User> fakeSuccessUserCallback;
 
     @Test
     public void searchSuccess_noResultsOnEmptyInput() {
@@ -97,6 +104,15 @@ public class ProfileViewModelUnitTest {
 
     @Test
     public void getUserByUidFailure() {
-        // TODO
+        ProfileViewModel vm = new ProfileViewModel(mockUserRepository);
+        String uid = "testUid";
+
+        FakeSuccessCallbackWithMessage<User> mockOnSuccess = new FakeSuccessCallbackWithMessage<>();
+        FakeFailTask<User> fakeTask = new FakeFailTask<>(new UserNotExistException());
+
+        when(mockUserRepository.getByUid(uid)).thenReturn(fakeTask);
+        vm.getUserByUid(uid, mockOnSuccess, fakeFailUserCallback);
+
+        verify(fakeFailUserCallback, times(1)).run();
     }
 }


### PR DESCRIPTION
- covers search
- covers failure of `getById`
- refactored so that all functions in user repo map directly to entities