### PR TITLE
test: fix create account failure. not start with login page

### DIFF
--- a/app/src/androidTest/java/com/cmput301f20t21/bookfriends/ui/login/CreateAccountActivityTest.java
+++ b/app/src/androidTest/java/com/cmput301f20t21/bookfriends/ui/login/CreateAccountActivityTest.java
@@ -30,10 +30,6 @@ public class CreateAccountActivityTest {
 
     @Test
     public void testIncorrectInput() throws InterruptedException {
-        ViewInteraction createAccountButton = onView(
-                allOf(withId(R.id.create_account_button), isDisplayed()));
-        createAccountButton.perform(click());
-
         ViewInteraction usernameField = onView(
                 allOf(withId(R.id.signup_username_field), isDisplayed()));
         usernameField.perform(replaceText("! User"), closeSoftKeyboard());


### PR DESCRIPTION
The tests start with CreateAccountActivity directly so it could not find the login button.