### PR TITLE
feat: notify users on being requested/accepted

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.3.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'com.google.android.gms:play-services-vision:20.1.2'
+    implementation "com.squareup.okhttp3:okhttp:4.9.0"
 
     implementation platform('com.google.firebase:firebase-bom:25.12.0')
     implementation 'com.google.firebase:firebase-auth'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-firestore'
     implementation 'com.google.firebase:firebase-storage:19.2.0'
+
+    implementation 'com.google.firebase:firebase-messaging'
+    implementation 'com.google.firebase:firebase-analytics'
+
     implementation 'com.firebaseui:firebase-ui-storage:6.2.0'
     implementation 'com.android.support:multidex:1.0.3'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
             android:label="@string/add_edit">
         </activity>
         <activity android:name=".ui.library.owned.OwnedDetailActivity"
+            android:parentActivityName=".MainActivity"
             android:label="@string/view">
         </activity>
         <activity
@@ -57,19 +58,23 @@
         </activity>
         <activity
             android:name="com.cmput301f20t21.bookfriends.ui.borrow.accepted.AcceptedDetailActivity"
+            android:parentActivityName=".MainActivity"
             android:label="@string/accepted_detail">
         </activity>
         <activity
             android:name="com.cmput301f20t21.bookfriends.ui.browse.BrowseDetailActivity"
+            android:parentActivityName=".MainActivity"
             android:label="@string/browse_detail">
         </activity>
 
         <activity
             android:name="com.cmput301f20t21.bookfriends.ui.borrow.requested.RequestedDetailActivity"
+            android:parentActivityName=".MainActivity"
             android:label="@string/requested_detail">
         </activity>
         <activity
             android:name="com.cmput301f20t21.bookfriends.ui.library.borrowed.BorrowedDetailActivity"
+            android:parentActivityName=".MainActivity"
             android:label="@string/borrowed_detail">
         </activity>
         <activity android:name=".ui.library.owned.RequestActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">
 
         <activity
@@ -83,6 +84,7 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
+        <meta-data android:name="firebase_messaging_auto_init_enabled" android:value="true" />
         <!-- firebase services -->
         <!-- https://firebase.google.com/docs/cloud-messaging/android/client#manifest -->
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,17 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
+
+        <!-- firebase services -->
+        <!-- https://firebase.google.com/docs/cloud-messaging/android/client#manifest -->
+        <service
+            android:name=".services.BookFriendsFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
@@ -3,7 +3,6 @@ package com.cmput301f20t21.bookfriends;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
@@ -18,8 +17,6 @@ import com.google.firebase.messaging.FirebaseMessaging;
 
 
 public class MainActivity extends AppCompatActivity {
-    private static final String TAG = "bfriends_messaging";
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -62,14 +59,12 @@ public class MainActivity extends AppCompatActivity {
         FirebaseMessaging.getInstance().subscribeToTopic(newTopic).continueWith(Void -> {
             if (oldTopic != null && !oldTopic.equals(newTopic)) {
                 FirebaseMessaging.getInstance().unsubscribeFromTopic(oldTopic).continueWith(Void1 -> {
-                    Log.e(TAG, "successfully un-subbed " + oldTopic);
                     return null;
                 });
             }
             SharedPreferences.Editor editor = sharedPref.edit();
             editor.putString(getString(R.string.saved_cloud_messaging_topic), newTopic);
             editor.apply();
-            Log.e(TAG, "successfully subbed " + newTopic);
             return null;
         });
     }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
@@ -2,15 +2,25 @@ package com.cmput301f20t21.bookfriends;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Message;
+import android.util.Log;
 
+import com.cmput301f20t21.bookfriends.repositories.api.AuthRepository;
+import com.cmput301f20t21.bookfriends.repositories.api.UserRepository;
+import com.cmput301f20t21.bookfriends.repositories.impl.AuthRepositoryImpl;
 import com.cmput301f20t21.bookfriends.ui.login.LoginActivity;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.RemoteMessage;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 
 public class MainActivity extends AppCompatActivity {
 
@@ -34,5 +44,16 @@ public class MainActivity extends AppCompatActivity {
 
         // this intent should contain the user class that is used to log in?
         // Intent userIntent = getIntent();
+
+        String TAG = "bfriends_messaging";
+        final String username = AuthRepositoryImpl.getInstance().getCurrentUser().getUsername();
+        FirebaseMessaging.getInstance().subscribeToTopic(username)
+                .addOnCompleteListener(task -> {
+                    if (!task.isSuccessful()) {
+                        Log.e(TAG, "failed sub to " + username);
+                    }
+                    Log.e(TAG, "successfully sub to " + username);
+                });
+
     }
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/MainActivity.java
@@ -9,6 +9,7 @@ import com.cmput301f20t21.bookfriends.repositories.api.AuthRepository;
 import com.cmput301f20t21.bookfriends.repositories.api.UserRepository;
 import com.cmput301f20t21.bookfriends.repositories.impl.AuthRepositoryImpl;
 import com.cmput301f20t21.bookfriends.ui.login.LoginActivity;
+import com.cmput301f20t21.bookfriends.utils.NotificationSender;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
@@ -42,9 +43,11 @@ public class MainActivity extends AppCompatActivity {
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
         NavigationUI.setupWithNavController(navView, navController);
 
-        // this intent should contain the user class that is used to log in?
-        // Intent userIntent = getIntent();
+        subscribeToNotifications(); // subscribe to incoming notifications
+        initNotificationSender(); // prepare util singleton for future notification sending
+    }
 
+    private void subscribeToNotifications() {
         String TAG = "bfriends_messaging";
         final String username = AuthRepositoryImpl.getInstance().getCurrentUser().getUsername();
         FirebaseMessaging.getInstance().subscribeToTopic(username)
@@ -54,6 +57,9 @@ public class MainActivity extends AppCompatActivity {
                     }
                     Log.e(TAG, "successfully sub to " + username);
                 });
+    }
 
+    private void initNotificationSender() {
+        NotificationSender.getInstance();
     }
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/impl/AuthRepositoryImpl.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/impl/AuthRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 public class AuthRepositoryImpl implements AuthRepository {
     private FirebaseAuth mAuth;
@@ -47,7 +48,10 @@ public class AuthRepositoryImpl implements AuthRepository {
     }
 
     public void signOut() {
-        mAuth.signOut();
+        FirebaseMessaging.getInstance().unsubscribeFromTopic(getCurrentUser().getUsername()).continueWith(Void -> {
+            mAuth.signOut();
+            return null;
+        });
     }
 
     public Task<Void> updateEmail(String email) {

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
@@ -1,17 +1,28 @@
 package com.cmput301f20t21.bookfriends.services;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
+import com.cmput301f20t21.bookfriends.R;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class BookFriendsFirebaseMessagingService extends FirebaseMessagingService {
     private static final String TAG = "bfriends_messaging";
+    private static final String CHANNEL_ID = "BOOKFRIENDS_NOTIFICATION_CHANNEL_ID";
+    private AtomicInteger onetimeId = new AtomicInteger();
+
     @Override
     public void onNewToken(@NonNull String s) {
         super.onNewToken(s);
@@ -23,6 +34,15 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
         Log.e(TAG, "From: " + remoteMessage.getFrom());
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.no_image)
+                .setContentTitle(remoteMessage.getNotification().getTitle())
+                .setContentText(remoteMessage.getNotification().getBody())
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+
+
+        NotificationManagerCompat nm = NotificationManagerCompat.from(this);
+        nm.notify(onetimeId.get(), builder.build());
 
         // Check if message contains a data payload.
         if (remoteMessage.getData().size() > 0) {
@@ -35,4 +55,27 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
         }
 
     }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+    }
+
+    private void createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "Book Friends Notification Channel";
+            String description = "description";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
@@ -10,9 +10,6 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 import com.cmput301f20t21.bookfriends.R;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -38,8 +35,7 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
                 .setSmallIcon(R.drawable.no_image)
                 .setContentTitle(remoteMessage.getNotification().getTitle())
                 .setContentText(remoteMessage.getNotification().getBody())
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
-
+                .setPriority(NotificationCompat.PRIORITY_HIGH);
 
         NotificationManagerCompat nm = NotificationManagerCompat.from(this);
         nm.notify(onetimeId.get(), builder.build());

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
@@ -4,6 +4,9 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -15,19 +18,20 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
         Log.e(TAG, "Refreshed token: " + s);
     }
 
+    // https://firebase.google.com/docs/cloud-messaging/android/send-multiple#java_3
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
-        Log.d(TAG, "From: " + remoteMessage.getFrom());
+        Log.e(TAG, "From: " + remoteMessage.getFrom());
 
         // Check if message contains a data payload.
         if (remoteMessage.getData().size() > 0) {
-            Log.d(TAG, "Message data payload: " + remoteMessage.getData());
+            Log.e(TAG, "Message data payload: " + remoteMessage.getData());
         }
 
         // Check if message contains a notification payload.
         if (remoteMessage.getNotification() != null) {
-            Log.d(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
+            Log.e(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
         }
 
     }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
@@ -33,7 +33,7 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
     @Override
     public void onNewToken(@NonNull String s) {
         super.onNewToken(s);
-        Log.e(TAG, "Refreshed token: " + s);
+        Log.d(TAG, "Refreshed token: " + s);
     }
 
     // https://firebase.google.com/docs/cloud-messaging/android/send-multiple#java_3
@@ -52,11 +52,11 @@ public class BookFriendsFirebaseMessagingService extends FirebaseMessagingServic
 
         // Check if message contains a data payload.
         if (remoteMessage.getData().size() > 0) {
-            Log.e(TAG, "Message data payload: " + remoteMessage.getData());
+            Log.d(TAG, "Message data payload: " + remoteMessage.getData());
         }
         // Check if message contains a notification payload.
         if (remoteMessage.getNotification() != null) {
-            Log.e(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
+            Log.d(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
         }
 
         Task<PendingIntent> buildIntentTask = buildIntent(remoteMessage);

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/services/BookFriendsFirebaseMessagingService.java
@@ -1,0 +1,34 @@
+package com.cmput301f20t21.bookfriends.services;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+public class BookFriendsFirebaseMessagingService extends FirebaseMessagingService {
+    private static final String TAG = "bfriends_messaging";
+    @Override
+    public void onNewToken(@NonNull String s) {
+        super.onNewToken(s);
+        Log.e(TAG, "Refreshed token: " + s);
+    }
+
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        super.onMessageReceived(remoteMessage);
+        Log.d(TAG, "From: " + remoteMessage.getFrom());
+
+        // Check if message contains a data payload.
+        if (remoteMessage.getData().size() > 0) {
+            Log.d(TAG, "Message data payload: " + remoteMessage.getData());
+        }
+
+        // Check if message contains a notification payload.
+        if (remoteMessage.getNotification() != null) {
+            Log.d(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
+        }
+
+    }
+}

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
@@ -1,7 +1,5 @@
 package com.cmput301f20t21.bookfriends.ui.browse;
 
-import android.util.Log;
-
 import androidx.lifecycle.ViewModel;
 
 import com.cmput301f20t21.bookfriends.callbacks.OnFailCallback;
@@ -15,7 +13,6 @@ import com.cmput301f20t21.bookfriends.utils.NotificationSender;
 
 public class BrowseDetailViewModel extends ViewModel {
     private final RequestRepository requestRepository;
-    private final AuthRepository authRepository;
     private final String currentUsername;
 
     public BrowseDetailViewModel() {
@@ -24,7 +21,6 @@ public class BrowseDetailViewModel extends ViewModel {
 
     public BrowseDetailViewModel(AuthRepository authRepository, RequestRepository requestRepository) {
         this.requestRepository = requestRepository;
-        this.authRepository = authRepository;
         currentUsername = authRepository.getCurrentUser().getUsername();
     }
 
@@ -32,13 +28,12 @@ public class BrowseDetailViewModel extends ViewModel {
         requestRepository
                 .sendRequest(currentUsername, book.getId())
                 .addOnSuccessListener(requestId -> {
-                    NotificationSender.getInstance().request(book, authRepository.getCurrentUser(), res -> {
-                        Log.e("bfriends", res);
-                        successCallback.run();
-                    }, err -> {
-                        err.printStackTrace();
-                        failCallback.run();
-                    });
+                    NotificationSender.getInstance().request(book, currentUsername,
+                            res -> successCallback.run(),
+                            err -> {
+                                err.printStackTrace();
+                                failCallback.run();
+                            });
                 })
                 .addOnFailureListener(e -> failCallback.run());
     }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
@@ -1,17 +1,21 @@
 package com.cmput301f20t21.bookfriends.ui.browse;
 
+import android.util.Log;
+
 import androidx.lifecycle.ViewModel;
 
 import com.cmput301f20t21.bookfriends.callbacks.OnFailCallback;
 import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallback;
 import com.cmput301f20t21.bookfriends.entities.Book;
-import com.cmput301f20t21.bookfriends.repositories.impl.AuthRepositoryImpl;
-import com.cmput301f20t21.bookfriends.repositories.impl.RequestRepositoryImpl;
 import com.cmput301f20t21.bookfriends.repositories.api.AuthRepository;
 import com.cmput301f20t21.bookfriends.repositories.api.RequestRepository;
+import com.cmput301f20t21.bookfriends.repositories.impl.AuthRepositoryImpl;
+import com.cmput301f20t21.bookfriends.repositories.impl.RequestRepositoryImpl;
+import com.cmput301f20t21.bookfriends.utils.NotificationSender;
 
 public class BrowseDetailViewModel extends ViewModel {
     private final RequestRepository requestRepository;
+    private final AuthRepository authRepository;
     private final String currentUsername;
 
     public BrowseDetailViewModel() {
@@ -20,13 +24,22 @@ public class BrowseDetailViewModel extends ViewModel {
 
     public BrowseDetailViewModel(AuthRepository authRepository, RequestRepository requestRepository) {
         this.requestRepository = requestRepository;
+        this.authRepository = authRepository;
         currentUsername = authRepository.getCurrentUser().getUsername();
     }
 
     public void sendRequest(Book book, OnSuccessCallback successCallback, OnFailCallback failCallback) {
         requestRepository
                 .sendRequest(currentUsername, book.getId())
-                .addOnSuccessListener(requestId -> successCallback.run())
+                .addOnSuccessListener(requestId -> {
+                    NotificationSender.getInstance().request(book, authRepository.getCurrentUser(), res -> {
+                        Log.e("bfriends", res);
+                        successCallback.run();
+                    }, err -> {
+                        err.printStackTrace();
+                        failCallback.run();
+                    });
+                })
                 .addOnFailureListener(e -> failCallback.run());
     }
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/browse/BrowseDetailViewModel.java
@@ -51,7 +51,12 @@ public class BrowseDetailViewModel extends ViewModel {
                                 })
                                 .addOnFailureListener(e -> failCallback.run());
                     } else {
-                        successCallback.run();
+                        NotificationSender.getInstance().request(book, currentUsername,
+                                res -> successCallback.run(),
+                                err -> {
+                                    err.printStackTrace();
+                                    successCallback.run(); // success anyways as we don't want notifications break user flow
+                                });
                     }
                 })
                 .addOnFailureListener(e -> failCallback.run());

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/library/owned/RequestViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/library/owned/RequestViewModel.java
@@ -9,6 +9,8 @@
 
 package com.cmput301f20t21.bookfriends.ui.library.owned;
 
+import android.util.Log;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -18,6 +20,7 @@ import com.cmput301f20t21.bookfriends.entities.Request;
 import com.cmput301f20t21.bookfriends.repositories.impl.BookRepositoryImpl;
 import com.cmput301f20t21.bookfriends.repositories.impl.RequestRepositoryImpl;
 import com.cmput301f20t21.bookfriends.repositories.api.RequestRepository;
+import com.cmput301f20t21.bookfriends.utils.NotificationSender;
 import com.google.firebase.firestore.DocumentSnapshot;
 
 import java.util.ArrayList;
@@ -112,6 +115,13 @@ public class RequestViewModel extends ViewModel {
             for (int i = 0; i < requestsData.size(); i++) {
                 ids.add(requestsData.get(i).getId());
             }
+
+            NotificationSender.getInstance().accept(request, res -> {
+                Log.e("bfriends", "accept call response: " + res);
+            }, err -> {
+                err.printStackTrace();
+                Log.e("bfriends", "accept call failed: " + err.getLocalizedMessage());
+            });
             // clear the requests array anyways
             requestService.batchDeny(ids).addOnSuccessListener(aVoid1 -> {
                 requestsData.clear();

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
@@ -39,10 +39,10 @@ public class NotificationSender {
         Thread thread = new Thread() {
             @Override
             public void run() {
-//                String url = "https://postman-echo.com/get?foo1=bar1&foo2=bar2";
                 String url = ENDPOINT + "/accept/" + request.getId();
                 okhttp3.Request req = new okhttp3.Request.Builder()
                         .url(url)
+                        .get()
                         .build();
 
                 try {
@@ -61,7 +61,6 @@ public class NotificationSender {
         Thread thread = new Thread() {
             @Override
             public void run() {
-//                String url = "https://postman-echo.com/get?foo1=bar1&foo2=bar2";
                 String url = ENDPOINT + "/request/" + borrower.getUsername() + "/" + book.getId();
                 okhttp3.Request req = new okhttp3.Request.Builder()
                         .addHeader("connection", "close")

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
@@ -1,0 +1,85 @@
+package com.cmput301f20t21.bookfriends.utils;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.cmput301f20t21.bookfriends.callbacks.OnFailCallback;
+import com.cmput301f20t21.bookfriends.callbacks.OnFailCallbackWithMessage;
+import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallback;
+import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallbackWithMessage;
+import com.cmput301f20t21.bookfriends.entities.Book;
+import com.cmput301f20t21.bookfriends.entities.Request;
+import com.cmput301f20t21.bookfriends.entities.User;
+
+import java.io.IOException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+// https://stackoverflow.com/a/30604191/7358099
+public class NotificationSender {
+    private static final String TAG = "bfriends";
+    private static final String ENDPOINT = "http://155.138.226.148/notify";
+    private static NotificationSender instance = null;
+
+    private OkHttpClient client;
+
+    private NotificationSender() {
+        client = new OkHttpClient();
+    }
+
+    public static NotificationSender getInstance() {
+        if (instance == null) {
+            instance = new NotificationSender();
+        }
+        return instance;
+    }
+
+    public void accept(Request request, OnSuccessCallbackWithMessage<String> successCallback, OnFailCallbackWithMessage<IOException> failCallback) {
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+//                String url = "https://postman-echo.com/get?foo1=bar1&foo2=bar2";
+                String url = ENDPOINT + "/accept/" + request.getId();
+                okhttp3.Request req = new okhttp3.Request.Builder()
+                        .url(url)
+                        .build();
+
+                try {
+                    Response res = client.newCall(req).execute();
+                    successCallback.run(res.body().toString());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    failCallback.run(e);
+                }
+            }
+        };
+        thread.start();
+    }
+
+    public void request(Book book, User borrower, OnSuccessCallbackWithMessage<String> successCallback, OnFailCallbackWithMessage<IOException> failCallback) {
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+//                String url = "https://postman-echo.com/get?foo1=bar1&foo2=bar2";
+                String url = ENDPOINT + "/request/" + borrower.getUsername() + "/" + book.getId();
+                okhttp3.Request req = new okhttp3.Request.Builder()
+                        .addHeader("connection", "close")
+                        .url(url)
+                        .get()
+                        .build();
+                try {
+                    Log.e(TAG, "sending request: " + url);
+                    Response res = client.newCall(req).execute();
+                    Log.e(TAG, "response: " + res.body().toString());
+                    successCallback.run(res.body().toString());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    failCallback.run(e);
+                }
+            }
+        };
+        thread.start();
+    }
+
+}

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/utils/NotificationSender.java
@@ -1,15 +1,9 @@
 package com.cmput301f20t21.bookfriends.utils;
 
-import android.content.Context;
-import android.util.Log;
-
-import com.cmput301f20t21.bookfriends.callbacks.OnFailCallback;
 import com.cmput301f20t21.bookfriends.callbacks.OnFailCallbackWithMessage;
-import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallback;
 import com.cmput301f20t21.bookfriends.callbacks.OnSuccessCallbackWithMessage;
 import com.cmput301f20t21.bookfriends.entities.Book;
 import com.cmput301f20t21.bookfriends.entities.Request;
-import com.cmput301f20t21.bookfriends.entities.User;
 
 import java.io.IOException;
 
@@ -22,7 +16,7 @@ public class NotificationSender {
     private static final String ENDPOINT = "http://155.138.226.148/notify";
     private static NotificationSender instance = null;
 
-    private OkHttpClient client;
+    private final OkHttpClient client;
 
     private NotificationSender() {
         client = new OkHttpClient();
@@ -57,20 +51,18 @@ public class NotificationSender {
         thread.start();
     }
 
-    public void request(Book book, User borrower, OnSuccessCallbackWithMessage<String> successCallback, OnFailCallbackWithMessage<IOException> failCallback) {
+    public void request(Book book, String borrowerUsername, OnSuccessCallbackWithMessage<String> successCallback, OnFailCallbackWithMessage<IOException> failCallback) {
         Thread thread = new Thread() {
             @Override
             public void run() {
-                String url = ENDPOINT + "/request/" + borrower.getUsername() + "/" + book.getId();
+                String url = ENDPOINT + "/request/" + borrowerUsername + "/" + book.getId();
                 okhttp3.Request req = new okhttp3.Request.Builder()
                         .addHeader("connection", "close")
                         .url(url)
                         .get()
                         .build();
                 try {
-                    Log.e(TAG, "sending request: " + url);
                     Response res = client.newCall(req).execute();
-                    Log.e(TAG, "response: " + res.body().toString());
                     successCallback.run(res.body().toString());
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,4 +93,6 @@
     <string name="delete_cover_image">Delete cover image</string>
     <string name="address_search">Enter Address</string>
     <string name="request_book_successful">Request successfully sent</string>
+    <string name="preference_file_key">com.cmput301f20t21.bookfriends.PREFERENCE_FILE_KEY</string>
+    <string name="saved_cloud_messaging_topic">com.cmput301f20t21.bookfriends</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,7 @@
     <string name="request_book_successful">Request successfully sent</string>
     <string name="preference_file_key">com.cmput301f20t21.bookfriends.PREFERENCE_FILE_KEY</string>
     <string name="saved_cloud_messaging_topic">com.cmput301f20t21.bookfriends</string>
+    <string name="notification_channel_name">Book Friends Notification Channel</string>
+    <string name="notification_channel_description">description</string>
+    <string name="notification_channel_id">BOOKFRIENDS_NOTIFICATION_CHANNEL_ID</string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">155.138.226.148</domain>
+    </domain-config>
+</network-security-config>

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,88 @@
+import * as admin from 'firebase-admin'; 
+import express = require('express'); 
+
+admin.initializeApp({ credential: admin.credential.applicationDefault(), }); 
+const db = admin.firestore() 
+const port = 8081 
+const app = express() 
+const messaging = admin.messaging(); 
+
+async function fetchBookData(bookId) { 
+    let bookData;
+    try {
+        const ref = await db.collection('books').doc(bookId).get()
+        bookData = ref.data()
+        bookData.bookId = ref.id
+        bookData.title = bookData.title || 'Unknown Book'
+       
+    } catch (e) {
+        bookData = {
+            title: 'Unknown Book'
+        } 
+    }
+    return bookData
+}
+
+async function fetchRequestData(requestId) {
+    let rData;
+    try {
+        const ref = await db.collection('requests').doc(requestId).get()
+        rData = ref.data()
+        rData.bookId = rData.bookId || ''
+        rData.requestId = ref.id
+    } catch (e) {
+        // pass
+        rData.bookId = rData.bookId || ''
+        rData.requestId = ''
+    }
+
+    return rData
+}
+
+app.get('/request/:borrower/:bookId', async (req, res) => {
+    const book = await fetchBookData(req.params.bookId)
+    const owner = book.owner
+    const borrower = req.params.borrower
+
+    const msg = {
+          topic: owner,
+          notification: {
+              title: `${borrower} requested your book <${book.title}>`,
+              body: "click to see the book detail",
+          },
+        data: {
+            bookId: book.bookId
+        }
+      }
+    // console.log("sending message: ", msg)
+    const messageRes = await messaging.send(msg)
+    // console.log("sent response: ", messageRes)
+    res.send('ok')
+})
+
+app.get('/accept/:requestId', async (req, res) => {
+    const request = await fetchRequestData(req.params.requestId)
+    const book = await fetchBookData(request.bookId || '')
+    const owner = book.owner
+    const borrower = request.requester
+
+    const msg = {
+          topic: borrower,
+          notification: {
+              title: `${owner} accepted your request for <${book.title}>`,
+              body: "click to see the requested book detail",
+          },
+        data: {
+            bookId: request.bookId,
+            requestId: request.requestId
+        }
+      }
+    const msgRes = await messaging.send(msg)
+    res.send('ok')
+})
+
+app.listen(port, () => {
+    // const ref = await db.collection('books').doc('8Mf2bIeS6PaQaxIPo103').get();
+    // console.log(ref.id, '=>', ref.data())
+    console.log(`listening at http://localhost:${port}`)
+})


### PR DESCRIPTION
<details><summary>owner seeing its book getting requested:</summary>

![output12](https://user-images.githubusercontent.com/25297856/99628749-02c29e00-29f4-11eb-8ba8-cd40079032e1.gif)
</details>
<details><summary>borrower seeing its book getting accepted (ignore extra clicks after return from details)</summary>

![output13](https://user-images.githubusercontent.com/25297856/99628985-7e244f80-29f4-11eb-8e3f-2cbafb0544b0.gif)

</details>

:point_up: these are when the app is running. 

:point_down:  When the app does not run (totally cleaned up and thrown away), a bare simple notification is pushed. Clicking on that will simply go to app login <details><summary>when app quits but request comes in</summary>

![image](https://user-images.githubusercontent.com/25297856/99629301-060a5980-29f5-11eb-9642-279e48363c2a.png)
</details>

similar thing for accept
