### PR TITLE
fix: owned borrowed book need a request as BORROWED

### DIFF
--- a/app/src/main/java/com/cmput301f20t21/bookfriends/ui/library/owned/BorrowedOwnedDetailViewModel.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/ui/library/owned/BorrowedOwnedDetailViewModel.java
@@ -44,7 +44,7 @@ public class BorrowedOwnedDetailViewModel extends ViewModel {
 
     private void fetchRequest(String bookId) {
         requestRepository
-                .getRequestsByBookIdAndStatus(bookId, Arrays.asList(REQUEST_STATUS.RETURNING,REQUEST_STATUS.CLOSED))
+                .getRequestsByBookIdAndStatus(bookId, Arrays.asList(REQUEST_STATUS.RETURNING, REQUEST_STATUS.CLOSED, REQUEST_STATUS.BORROWED))
                 .addOnSuccessListener(requests -> request.setValue(requests.get(0)))
                 .addOnFailureListener(e -> errorMessage.setValue(SCAN_ERROR.UNEXPECTED));
     }


### PR DESCRIPTION
or else the borrowed book inside the owned list will have unexpected error in detail because the detail activity vm does not have the request (request status is BORROWED but filtered out)