### PR TITLE
fix: browse does not list "Requested" books

### DIFF
--- a/app/src/main/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeBookRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/fakes/repositories/FakeBookRepository.java
@@ -103,11 +103,6 @@ public class FakeBookRepository implements BookRepository {
     }
 
     @Override
-    public Task<QuerySnapshot> getDocumentBy(String isbn, String title, String author) {
-        return null;
-    }
-
-    @Override
     public Task<Book> updateBookStatus(Book book, BOOK_STATUS newStatus) {
         int i = books.indexOf(book);
         if (i != -1) {

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/BookRepository.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/api/BookRepository.java
@@ -20,6 +20,5 @@ public interface BookRepository {
     Task<Book> getBookById(String bookId);
     Task<List<Book>> batchGetBooks( List<String> bookIds);
     Task<List<Book>> getAvailableBooksForUser(String username);
-    Task<QuerySnapshot> getDocumentBy(String isbn, String title, String author);
     Task<Book> updateBookStatus(Book book, BOOK_STATUS newStatus);
 }

--- a/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/impl/BookRepositoryImpl.java
+++ b/app/src/main/java/com/cmput301f20t21/bookfriends/repositories/impl/BookRepositoryImpl.java
@@ -236,7 +236,7 @@ public class BookRepositoryImpl implements BookRepository {
     public Task<List<Book>> getAvailableBooksForUser(String username) {
         return bookCollection
                 .whereNotEqualTo("owner", username)
-                .whereEqualTo("status", BOOK_STATUS.AVAILABLE.toString())
+                .whereIn("status", Arrays.asList(BOOK_STATUS.AVAILABLE, BOOK_STATUS.REQUESTED))
                 .get()
                 .continueWith(task -> {
                     if (task.isSuccessful()) {
@@ -247,10 +247,6 @@ public class BookRepositoryImpl implements BookRepository {
                     }
                     throw new UnexpectedException();
                 });
-    }
-
-    public Task<QuerySnapshot> getDocumentBy(String isbn, String title, String author) {
-        return bookCollection.whereEqualTo("isbn", isbn).whereEqualTo("title", title).whereEqualTo("author", author).get();
     }
 
     /**


### PR DESCRIPTION
* Browse Fragment is not listing books with "Requested" status
* causing each book can have at most one request